### PR TITLE
Remove css-loader peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
   },
   "homepage": "https://github.com/zachariahtimothy/absurd-loader",
   "peerDependencies": {
-    "absurd": "^0.3.34",
-    "css-loader": "^0.9.1"
+    "absurd": "^0.3.34"
   },
   "devDependencies": {
   },


### PR DESCRIPTION
Hey,
I know you haven't been on this project for a while, but I'm using it for a project of mine.  
Forking it as my own is also a problem because I need the npm registry.
Anyway, `css-loader` is not needed as peerDependency, absurd is a css\html templating engine.